### PR TITLE
.first() => .eq(0)

### DIFF
--- a/js/jquery.form.wizard-3.0.4.js
+++ b/js/jquery.form.wizard-3.0.4.js
@@ -66,7 +66,7 @@
 			
 			this.steps = this.element.find(".step").hide();
 			
-			this.firstStep = this.steps.first().attr("id");
+			this.firstStep = this.steps.eq(0).attr("id");
 			this.activatedSteps = new Array();
 			this.isLastStep = false;
 			this.previousStep = undefined;


### PR DESCRIPTION
These are the changes we discussed via email earlier about using .eq(0) instead of .first() because of incompatibility with older versions of jQuery (< 1.4).
