### PR TITLE
Ability to override the attribute used for linking steps

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -434,7 +434,7 @@
 			validationOptions : undefined,
 			formPluginEnabled : false,
 			linkClass	: ".link",
-			linkAttr	: "val",
+			linkAttr	: "value",
 			submitStepClass : "submit_step",
 			back : ":reset",
 			next : ":submit",


### PR DESCRIPTION
Hi,
Just to begin, awesome plugin thecodemine, keep up the good work.

I have a small tweak taht you might like, around times when you may not wish to use an element's value to indicate the next step.

For example by default a link from a radio button would use it's value, but in some cases you may wish to have a different value to the id of the next step, for example for boolean inputs, where you may want to submit 1 / 0 rather than a string.

``` html
<input type="radio" name="mandatory" value="1"/>
<input type="radio" name="mandatory" value="0"/>
```

In this situation instead of using the value attribute (the default), you could use the rel. 

With this you could now have something like:

``` javascript
  $("#pushRuleWizard").formwizard({
            linkAttr: "rel"
        });
```

``` html
<input type="radio" name="mandatory" value="1" rel="addMandatoryResourcesStep"/>
<input type="radio" name="mandatory" value="0" rel="addOptionalResourcesStep" />
```
