### PR TITLE
Adding new event 'step_to_show'

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -256,7 +256,7 @@
 			}
 		},
 
-		_animate : function(oldStep, newStep, stepShownCallback){
+		_animate : function(oldStep, newStep, stepToShowCallback, stepShownCallback){
 			this._disableNavigation();
 			var old = this.steps.filter("#" + oldStep);
 			var current = this.steps.filter("#" + newStep);
@@ -264,6 +264,7 @@
 			current.find(":input").not(".wizard-ignore").removeAttr("disabled");
 			var wizard = this;
 			old.animate(wizard.options.outAnimation, wizard.options.outDuration, wizard.options.easing, function(){
+				stepToShowCallback.apply(wizard);
 				current.animate(wizard.options.inAnimation, wizard.options.inDuration, wizard.options.easing, function(){
 					if(wizard.options.focusFirstInput)
 						current.find(":input:first").focus();
@@ -330,7 +331,8 @@
 				this._checkIflastStep(step);
 				this.currentStep = step;
 				var stepShownCallback = function(){if(triggerStepShown)$(this.element).trigger('step_shown', $.extend({"isBackNavigation" : backwards},this._state()));};
-				this._animate(this.previousStep, step, stepShownCallback);
+				var stepToShowCallback = function(){if(triggerStepShown)$(this.element).trigger('step_to_show', $.extend({"isBackNavigation" : backwards},this._state()));};
+				this._animate(this.previousStep, step, stepToShowCallback, stepShownCallback);
 			};
 
 


### PR DESCRIPTION
It seems useful for an event to be thrown before the next page in the wizard is displayed, so that you can update UI elements without them displaying briefly to the user incorrectly before the current event which is trigger after the next page of the UI has been shown to the user.

I've added a new event for this.
