### PR TITLE
Bugfix: Problems when refreshing the page with history enabled

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -64,7 +64,9 @@
 				}
 			});
 			
-			$.bbq.removeState("_" + $(this.element).attr('id'));
+			if (this.options.historyEnabled) {
+				$.bbq.removeState("_" + $(this.element).attr('id'));
+			}
 
 			this.steps = this.element.find(".step").hide();
 


### PR DESCRIPTION
I've fixed a small issue in the form wizard: the "Next" button stops working after refreshing the browser on the second page of a historyEnabled wizard. Here's how to reproduce the problem: 

1) Go to the historyEnabled example here: http://thecodemine.org/examples/example_3_bbq_integration_history_handling.html
2) Click "Next"
3) Click your browser's refresh button
4) Try to click "Next" - nothing happens. 
