### PR TITLE
Stop double clicking on non-input next/previous buttons showing multiple steps

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -263,7 +263,7 @@
 			}
 		},
 
-		_animate : function(oldStep, newStep, stepToShowCallback, stepShownCallback){
+		_animate : function(oldStep, newStep, stepShownCallback){
 			this._disableNavigation();
 			var old = this.steps.filter("#" + oldStep);
 			var current = this.steps.filter("#" + newStep);
@@ -271,7 +271,6 @@
 			current.find(":input").not(".wizard-ignore").removeAttr("disabled");
 			var wizard = this;
 			old.animate(wizard.options.outAnimation, wizard.options.outDuration, wizard.options.easing, function(){
-				stepToShowCallback.apply(wizard);
 				current.animate(wizard.options.inAnimation, wizard.options.inDuration, wizard.options.easing, function(){
 					if(wizard.options.focusFirstInput)
 						current.find(":input:first").focus();
@@ -338,8 +337,7 @@
 				this._checkIflastStep(step);
 				this.currentStep = step;
 				var stepShownCallback = function(){if(triggerStepShown)$(this.element).trigger('step_shown', $.extend({"isBackNavigation" : backwards},this._state()));};
-				var stepToShowCallback = function(){if(triggerStepShown)$(this.element).trigger('step_to_show', $.extend({"isBackNavigation" : backwards},this._state()));};
-				this._animate(this.previousStep, step, stepToShowCallback, stepShownCallback);
+				this._animate(this.previousStep, step, stepShownCallback);
 			};
 
 


### PR DESCRIPTION
If you use a non-input element for the next/previous buttons (e.g. a link) you can get into a state where multiple steps are shown on the screen at once but only one is functional.

To prevent this from happening I've added some code so that the next/previous actions are only run if the links are enabled.

Sorry about the large number of commits, I have had to revert the last changes I sent as I foolishly didn't create a branch - the overall diff is what I want to push though.
