### PR TITLE
Updating top comment so that the licence information is kept when it is built with the Google Closure Compiler

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -1,5 +1,5 @@
-/*
- * jQuery wizard plug-in 3.0.7 (18-SEPT-2012)
+/**
+ * @license jQuery wizard plug-in 3.0.7 (18-SEPT-2012)
  *
  *
  * Copyright (c) 2012 Jan Sundman (jan.sundman[at]aland.net)


### PR DESCRIPTION
A really boring technical change that means that the licence information is kept when jquery.form.wizard is built with the Google Closure Compiler.
