### PR TITLE
if the button is disabled then don't perform its click action if it isn't an input

### DIFF
--- a/js/jquery.form.wizard.js
+++ b/js/jquery.form.wizard.js
@@ -146,6 +146,10 @@
 		},
 
 		_next : function(){
+			if(this.nextButton.attr('disabled')){
+				return false;
+			}
+
 			if(this.options.validationEnabled){
 				if(!this.element.valid()){
 					this.element.validate().focusInvalid();
@@ -190,6 +194,10 @@
 
 		_back : function(){
 			if(this.activatedSteps.length > 0){
+				if(this.backButton.attr('disabled')){
+					return false;
+				}
+
 				if(this.options.historyEnabled){
 					this._updateHistory(this.activatedSteps[this.activatedSteps.length - 2]);
 				}else{


### PR DESCRIPTION
If you use a non-input element for the next/previous buttons (e.g. a link) you can get into a state where multiple steps are shown on the screen at once but only one is functional.

To prevent this from happening I've added some code so that the next/previous actions are only run if the links are enabled.

This is a cleaned up version of pull request #26.
